### PR TITLE
Spike-address-fe-stack

### DIFF
--- a/frontend/template.yaml
+++ b/frontend/template.yaml
@@ -5,125 +5,20 @@ Parameters:
   EnvironmentName:
     Description: An environment name that is prefixed to resource names.
     Type: String
+  VPC:
+    Description: VPC ID for the services
+    Type: String
+  PublicSubnet1:
+    Description: Subnet 1 for ALB
+    Type: String
+  PublicSubnet2:
+    Description: Subnet 2 for ALB
+    Type: String
   ECRrepo:
     Type: String
     Description: "Enter the name of the ECR image and tag. Eg For the repo 123.dkr.ecr.eu-west-2.amazonaws.com/test:1 enter test:1"
 
 Resources:
-
-  ## Networking
-
-  VPC:
-    Type: AWS::EC2::VPC
-    Properties:
-      CidrBlock: "10.0.0.0/16"
-      EnableDnsSupport: true
-      EnableDnsHostnames: true
-      Tags:
-        - Key: Name
-          Value: !Ref EnvironmentName
-
-  InternetGateway:
-    Type: AWS::EC2::InternetGateway
-    Properties:
-      Tags:
-        - Key: Name
-          Value: !Ref EnvironmentName
-
-  InternetGatewayAttachment:
-    DependsOn:
-      - VPC
-      - InternetGateway
-    Type: AWS::EC2::VPCGatewayAttachment
-    Properties:
-      InternetGatewayId: !Ref InternetGateway
-      VpcId: !Ref VPC
-
-  PublicSubnet1:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-      - VPC
-    Properties:
-      VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 0, !GetAZs '' ]
-      CidrBlock: "10.0.10.0/24"
-      MapPublicIpOnLaunch: true
-      Tags:
-        - Key: Name
-          Value: !Sub ${EnvironmentName} Public Subnet (AZ1)
-
-  PublicSubnet2:
-    Type: AWS::EC2::Subnet
-    DependsOn:
-      - VPC
-    Properties:
-      VpcId: !Ref VPC
-      AvailabilityZone: !Select [ 0, !GetAZs  '' ]
-      CidrBlock: "10.0.11.0/24"
-      MapPublicIpOnLaunch: true
-      Tags:
-        - Key: Name
-          Value: !Sub ${EnvironmentName} Public Subnet (AZ2)
-
-  NatGateway1EIP:
-    Type: AWS::EC2::EIP
-    DependsOn:
-      - InternetGatewayAttachment
-    Properties:
-      Domain: vpc
-
-  NatGateway2EIP:
-    Type: AWS::EC2::EIP
-    DependsOn:
-      - InternetGatewayAttachment
-    Properties:
-      Domain: vpc
-
-  NatGateway1:
-    Type: AWS::EC2::NatGateway
-    DependsOn:
-      - NatGateway1EIP
-      - PublicSubnet1
-    Properties:
-      AllocationId: !GetAtt NatGateway1EIP.AllocationId
-      SubnetId: !Ref PublicSubnet1
-
-  NatGateway2:
-    Type: AWS::EC2::NatGateway
-    DependsOn:
-      - NatGateway2EIP
-      - PublicSubnet2
-    Properties:
-      AllocationId: !GetAtt NatGateway2EIP.AllocationId
-      SubnetId: !Ref PublicSubnet2
-
-  PublicRouteTable:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId: !Ref VPC
-      Tags:
-        - Key: Name
-          Value: !Sub ${EnvironmentName} Public Routes
-
-  DefaultPublicRoute:
-    Type: AWS::EC2::Route
-    DependsOn: InternetGatewayAttachment
-    Properties:
-      RouteTableId: !Ref PublicRouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId: !Ref InternetGateway
-
-  PublicSubnet1RouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref PublicRouteTable
-      SubnetId: !Ref PublicSubnet1
-
-  PublicSubnet2RouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      RouteTableId: !Ref PublicRouteTable
-      SubnetId: !Ref PublicSubnet2
 
 ################ Role
   ECSTaskExecutionRole:
@@ -167,9 +62,6 @@ Resources:
 ################  Application Load balancer.
   ALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    DependsOn:
-      - PublicSubnet1
-      - PublicSubnet2
     Properties:
       Name: AddressCriFrontALB
       Subnets:
@@ -181,8 +73,6 @@ Resources:
 ################ Target Group
   AddressTargetGroup1:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    DependsOn:
-      - VPC
     Properties:
       Name: !Sub ${AWS::StackName}-tg
       VpcId: !Ref VPC
@@ -205,7 +95,6 @@ Resources:
 ################ Load balancer Security group
   FargateAlbSG:
     Type: 'AWS::EC2::SecurityGroup'
-    DependsOn: VPC
     Properties:
       GroupDescription: SG for the Fargate ALB
       GroupName: !Sub ${AWS::StackName}-ALB-Security-group
@@ -239,6 +128,7 @@ Resources:
     DependsOn:
       - FargateContainerSG
       - ALB
+      - AddressTargetGroup1
     Properties:
       ServiceName: !Sub ${AWS::StackName}-Address-frontend
       LaunchType: FARGATE
@@ -267,18 +157,6 @@ Resources:
           ContainerName: !Sub ${AWS::StackName}-Address-frontend
 
 Outputs:
-  VPC:
-    Description: A reference to the created VPC
-    Value: !Ref VPC
-
-  PublicSubnet1:
-    Description: A reference to the public subnet in the 1st Availability Zone
-    Value: !Ref PublicSubnet1
-
-  PublicSubnet2:
-    Description: A reference to the public subnet in the 2nd Availability Zone
-    Value: !Ref PublicSubnet2
-
   Service:
     Description: A reference to the service created
     Value: !Ref Service


### PR DESCRIPTION
Spike add fe address stack

This creates all the resources needed to run the address repo in AWS fargate with a blue green deployment scheme.

Worth noting that AWS Cloudformation doesnt currently support blue green deployments for ECS, it is possible to use clickops but this is an alternative provided by them.

See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/blue-green.html#blue-green-required

More info why here: https://github.com/aws/containers-roadmap/issues/130


To deploy from Github action, you need to push a docker image to ECR and modify this stack with the updated ECR value, then upload the updated stack to cloud formation, this will trigger AWS to do a code deploy with blue green deployment.

One issue I see is that this needs to be accessible in FE github action.

Todo:
- Harden the spike?
- PR on the FE repo for the github action.
        - This would be a simple docker build, docker push, take the ecr name and inject it into the template and do a cloudformation update. 