### PR TITLE
[KBV 354] txma deployment workflow to build

### DIFF
--- a/.github/workflows/post-merge-publish-sqs-to-build.yaml
+++ b/.github/workflows/post-merge-publish-sqs-to-build.yaml
@@ -1,0 +1,48 @@
+name: Publish SQS to dev
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_sqs_to_build:
+    name: Publish SQS to build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      AWS_REGION: eu-west-2
+      STACK_NAME: di-ipv-cri-address-txma
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup SAM
+        uses: aws-actions/setup-sam@v1
+
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.SQS_GH_ACTIONS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t sqs/template.yaml
+
+      - name: SAM build
+        run: sam build -t sqs/template.yaml
+
+      - name: SAM package
+        run: |
+          sam package -t sqs/template.yaml  \
+            --s3-bucket ${{ secrets.SQS_ARTIFACT_SOURCE_BUCKET_NAME }} \
+            --region ${{ env.AWS_REGION }} --output-template-file=cf-template.yaml
+
+      - name: Zip the CloudFormation template
+        run: zip template.zip cf-template.yaml
+
+      - name: Upload zipped CloudFormation artifact to S3
+        env:
+          SQS_ARTIFACT_SOURCE_BUCKET_NAME: ${{ secrets.SQS_ARTIFACT_SOURCE_BUCKET_NAME }}
+        run: aws s3 cp template.zip "s3://$SQS_ARTIFACT_SOURCE_BUCKET_NAME/template.zip"

--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ TxMA SQS for dev:
 |-------------------------------------| ----------- |
 | DEV_SQS_ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
 | DEV_SQS_GH_ACTIONS_ROLE_ARN         | Assumed role IAM ARN |
-| DEV_SQS_SIGNING_PROFILE_NAME        | Signing profile name |
 
+TxMA SQS for staging:
+
+| Secret                      | Description |
+|-----------------------------| ----------- |
+| SQS_ARTIFACT_SOURCE_BUCKET_NAME | Upload artifact bucket |
+| SQS_GH_ACTIONS_ROLE_ARN     | Assumed role IAM ARN |
 
 Frontend test dev:
 


### PR DESCRIPTION
## Proposed changes

### What changed

Added GitHub workflow for the TxMA deployment to build

### Why did it change

This enables the TxMA configuration to be deployed to build and promoted down the environments

### Issue tracking

- [KBV-354](https://govukverify.atlassian.net/browse/KBV-354)

## Checklists

### Environment variables or secrets

- [X] Documented in the [README](./blob/main/README.md)
- [X] Added to GitHub repository secrets

### Other considerations

dev platform team stack already created in build, stacks will need to be created for the downstream environments
