### PR TITLE
KBV-354  Infra for TxMA is now common across CRIs, drop Address refs

### DIFF
--- a/sqs/template.yaml
+++ b/sqs/template.yaml
@@ -49,7 +49,7 @@ Resources:
         - Key: Service
           Value: "ci/cd"
         - Key: Source
-          Value: "alphagov/di-ipv-cri-address-infrastructure/sqs/template.yaml"
+          Value: "alphagov/di-ipv-cri-common-infrastructure/sqs/template.yaml"
 
   AuditEventQueuePolicy:
     Type: AWS::SQS::QueuePolicy
@@ -80,7 +80,7 @@ Resources:
         - Key: Service
           Value: "ci/cd"
         - Key: Source
-          Value: "alphagov/di-ipv-cri-address-infrastructure/sqs/template.yaml"
+          Value: "alphagov/di-ipv-cri-common-infrastructure/sqs/template.yaml"
 
   AuditEventQueueEncryptionKey:
     Type: AWS::KMS::Key
@@ -114,7 +114,7 @@ Resources:
         - Key: Service
           Value: "ci/cd"
         - Key: Source
-          Value: "alphagov/di-ipv-cri-address-infrastructure/sqs/template.yaml"
+          Value: "alphagov/di-ipv-cri-common-infrastructure/sqs/template.yaml"
 
   AuditEventQueueEncryptionKeyAlias:
     Type: AWS::KMS::Alias
@@ -158,7 +158,7 @@ Resources:
         - Key: Service
           Value: "ci/cd"
         - Key: Source
-          Value: "alphagov/di-ipv-cri-address-infrastructure/sqs/template.yaml"
+          Value: "alphagov/di-ipv-cri-common-infrastructure/sqs/template.yaml"
 
 Outputs:
   AuditEventQueueName:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Infra to support sending events to TxMA is now common across CRIs, so drop the Address CRI specific references.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-354](https://govukverify.atlassian.net/browse/KBV-354)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
