### PR TITLE
OJ-1851: Fix permissions for event bridge

### DIFF
--- a/txma/template.yaml
+++ b/txma/template.yaml
@@ -76,14 +76,6 @@ Resources:
               Service: events.amazonaws.com
             Action: SQS:SendMessage
             Resource: !GetAtt AuditEventQueue.Arn
-          - Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-            Action:
-              - "kms:Decrypt"
-              - "kms:GenerateDataKey"
-            Resource:
-              - !GetAtt AuditEventQueueEncryptionKey.Arn
 
   AuditEventDeadLetterQueue:
     Type: AWS::SQS::Queue
@@ -127,6 +119,13 @@ Resources:
             Action:
               - 'kms:decrypt'
             Resource: '*'
+          - Sid: 'Allow EventBridge to generate data key and decrypt'
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action:
+              - "kms:decrypt"
+              - "kms:GenerateDataKey"
       Tags:
         - Key: Name
           Value: !Join


### PR DESCRIPTION
The permissions for kms:decrypt and kms:GenerateDataKey were set on the SQS Queue not the KMS key so it wasn't applying the permissions.