### PR TITLE
OJ-2618: Exports the AuditEventDeadLetterQueue.Arn

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Credential Issuer Common Infrastructure Release Notes
 
+## 14/06/2024
+Export AuditEventDeadLetterQueue.Arn so that it can be used by event buses
+
 ## 30/05/2024
 
 Added REALEASE_NOTES and updated README

--- a/txma/template.yaml
+++ b/txma/template.yaml
@@ -217,3 +217,10 @@ Outputs:
     Value: !GetAtt AuditEventQueueEncryptionKey.Arn
     Export:
       Name: AuditEventQueueEncryptionKeyArn
+
+  AuditEventDLQArn:
+    Condition: IsNotDevEnvironment
+    Description: The ARN of the audit event SQS queue DLQ
+    Value: !GetAtt AuditEventDeadLetterQueue.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-AuditEventDLQArn


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Include `AuditEventDeadLetterQueue.Arn` in outputs 

### Screenshots

![Screenshot 2024-06-13 at 2 18 19 PM](https://github.com/govuk-one-login/ipv-cri-common-infrastructure/assets/40401118/b5b75f0e-aa5b-4572-8c65-8be80f6853b4)

### Why did it change

So that it can be used by NINo for the `TxMaAuditEventRule` `DeadLetterConfig`

### Issue tracking

- [OJ-2618](https://govukverify.atlassian.net/browse/OJ-2618)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-2618]: https://govukverify.atlassian.net/browse/OJ-2618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ