### PR TITLE
OJ-2735: Exports AuditEventQueueArn for the test harness

### DIFF
--- a/txma/template.yaml
+++ b/txma/template.yaml
@@ -289,6 +289,12 @@ Outputs:
     Export:
       Name: AuditEventQueueUrl
 
+  AuditEventQueueArn:
+    Description: The ARN of the SQS audit event queue. Needed to pull messages off the queue
+    Value: !GetAtt AuditEventQueue.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-AuditEventQueueArn
+
   AuditEventQueueEncryptionKeyArn:
     Description: The ARN of the KMS key used to encrypt audit event messages in the SQS queue
     Value: !GetAtt AuditEventQueueEncryptionKey.Arn


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Exports `AuditEventQueueArn` 

### Why did it change

Test harness needs it for event trigger

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2735](https://govukverify.atlassian.net/browse/OJ-2735)

[PR where this output is being used ](https://github.com/govuk-one-login/ipv-cri-common-lambdas/pull/337)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed



[OJ-2735]: https://govukverify.atlassian.net/browse/OJ-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ