### PR TITLE
IPS-1529: Add bucket policy

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -240,7 +240,8 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              AWS: "*"
+              Service:
+                - lambda.amazonaws.com
             Condition:
               StringEquals:
                   "aws:ResourceTag/key_consumer_type": "manage"

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -188,21 +188,7 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:root"
-          - Sid: "Bucket permissions: key_consumer_type is manage"
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Action:
-              - s3:Get*
-              - s3:Put*
-            Resource: !Sub
-              - arn:aws:s3:::${bucketName}/jwks.json
-              - bucketName: !Ref PublishedKeysS3Bucket
-            Condition:
-              StringEquals:
-                  "aws:ResourceTag/key_consumer_type": "manage"
-          - Sid: "Bucket permissions: key_consumer_type is use"
+          - Sid: "Bucket permissions"
             Effect: Allow
             Principal:
               Service:
@@ -218,7 +204,7 @@ Resources:
                   "aws:ResourceTag/key_consumer_type":
                     - "manage"
                     - "use"
-          - Sid: "Object permissions: key_consumer_type is use"
+          - Sid: "Object permissions"
             Effect: Allow
             Principal:
               Service:
@@ -254,7 +240,11 @@ Resources:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
-              AWS: !ImportValue OAuthGenerationFunctionRoleArn
+              AWS: "*"
+            Condition:
+              StringEquals:
+                  "aws:ResourceTag/key_consumer_type": "manage"
+                  "aws:ResourceAccount": !Sub ${AWS::AccountId}
         Version: "2012-10-17"
       Policies:
         - PolicyName: PublishedKeysS3BucketPolicy

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -6,12 +6,22 @@ Parameters:
   Environment:
     Type: String
     Default: "none"
+  PermissionsBoundary:
+    Type: String
+    Description: The ARN of the permissions boundary to apply to any role created by the template
+    Default: "none"
   ServiceName:
     Type: String
     Default: "none"
+
+Conditions:
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
     
 Resources:
-
   CriVcSigningKey1:
     Type: AWS::KMS::Key
     Properties:
@@ -158,6 +168,109 @@ Resources:
       Tags:
         - Key: "Description"
           Value: "Published OAuth or DID keys bucket for key rotation state machine"
+
+  PublishedKeysS3BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref PublishedKeysS3Bucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "Delegate IAM Access"
+            Action:
+              - 's3:*'
+            Effect: Allow
+            Resource:
+              - !GetAtt PublishedKeysS3Bucket.Arn
+              - !Sub
+                - "${Bucket}/*"
+                - Bucket: !GetAtt PublishedKeysS3Bucket.Arn
+            Principal:
+              AWS:
+                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          - Sid: "Bucket permissions: key_consumer_type is manage"
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - s3:Get*
+              - s3:Put*
+            Resource: !Sub
+              - arn:aws:s3:::${bucketName}/jwks.json
+              - bucketName: !Ref PublishedKeysS3Bucket
+            Condition:
+              StringEquals:
+                  "aws:ResourceTag/key_consumer_type": "manage"
+          - Sid: "Bucket permissions: key_consumer_type is use"
+            Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+                - lambda.amazonaws.com
+            Action:
+              - s3:ListBucket
+              - s3:GetBucketLocation
+            Resource:
+              - !GetAtt PublishedKeysS3Bucket.Arn
+            Condition:
+              StringEquals:
+                  "aws:ResourceTag/key_consumer_type":
+                    - "manage"
+                    - "use"
+          - Sid: "Object permissions: key_consumer_type is use"
+            Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+                - lambda.amazonaws.com
+            Action:
+              - "s3:GetObject"
+            Resource: !Sub
+              - arn:aws:s3:::${bucketName}/jwks.json
+              - bucketName: !Ref PublishedKeysS3Bucket  
+            Condition:
+              StringEquals:
+                  "aws:ResourceTag/key_consumer_type":
+                    - "manage"
+                    - "use"         
+          - Sid: "Deny all access if not using SecureTransport"
+            Effect: Deny
+            Principal:
+              AWS: '*'
+            Action: '*'
+            Resource: !Sub
+              - arn:aws:s3:::${bucketName}/*
+              - bucketName: !Ref PublishedKeysS3Bucket
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+
+  PublishedKeysS3BucketLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !ImportValue OAuthGenerationFunctionRoleArn
+        Version: "2012-10-17"
+      Policies:
+        - PolicyName: PublishedKeysS3BucketPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:Get*
+                  - s3:Put*
+                Resource:
+                  - !Sub ${PublishedKeysS3Bucket.Arn}/jwks.json
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
 
 Outputs:
 

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -182,9 +182,7 @@ Resources:
             Effect: Allow
             Resource:
               - !GetAtt PublishedKeysS3Bucket.Arn
-              - !Sub
-                - "${Bucket}/*"
-                - Bucket: !GetAtt PublishedKeysS3Bucket.Arn
+              - !Sub ${PublishedKeysS3Bucket.Arn}/*
             Principal:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:root"
@@ -212,9 +210,8 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - "s3:GetObject"
-            Resource: !Sub
-              - arn:aws:s3:::${bucketName}/jwks.json
-              - bucketName: !Ref PublishedKeysS3Bucket  
+            Resource:
+              - !Sub ${PublishedKeysS3Bucket.Arn}/*
             Condition:
               StringEquals:
                   "aws:ResourceTag/key_consumer_type":
@@ -225,9 +222,8 @@ Resources:
             Principal:
               AWS: '*'
             Action: '*'
-            Resource: !Sub
-              - arn:aws:s3:::${bucketName}/*
-              - bucketName: !Ref PublishedKeysS3Bucket
+            Resource:
+              - !Sub ${PublishedKeysS3Bucket.Arn}/*
             Condition:
               Bool:
                 aws:SecureTransport: false
@@ -257,7 +253,7 @@ Resources:
                   - s3:Get*
                   - s3:Put*
                 Resource:
-                  - !Sub ${PublishedKeysS3Bucket.Arn}/jwks.json
+                  - !Sub ${PublishedKeysS3Bucket.Arn}/*
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary


### PR DESCRIPTION
### What changed

- Add bucket policy. Its permissions statements are:
  1.  Delegate IAM Access for Root Access
  2. Bucket permissions: Allow APIGW and Lambda to `ListBucket` if they have the use tag (also allow if manage)
  3. Object permissions: Allow APIGW and Lambda to `GetObject` if they have the use tag (also allow if manage)
  4. Deny access if not using SecureTransport

- Add lambda role:
  1. Can only be assumed by a resource:
    a. With the tag `key_consumer_type`: `manage`
    b. In the same AWS account

### Why did it change

- Moved from key-rotation stack to this repo: https://github.com/govuk-one-login/identity-key-rotation/pull/81

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1529](https://govukverify.atlassian.net/browse/IPS-1529)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1529]: https://govukverify.atlassian.net/browse/IPS-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ