### PR TITLE
IPS-1529: Update bucket policy

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -6,21 +6,10 @@ Parameters:
   Environment:
     Type: String
     Default: "none"
-  PermissionsBoundary:
-    Type: String
-    Description: The ARN of the permissions boundary to apply to any role created by the template
-    Default: "none"
   ServiceName:
     Type: String
     Default: "none"
 
-Conditions:
-  UsePermissionsBoundary:
-    Fn::Not:
-      - Fn::Equals:
-          - !Ref PermissionsBoundary
-          - "none"
-    
 Resources:
   CriVcSigningKey1:
     Type: AWS::KMS::Key
@@ -176,7 +165,7 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          - Sid: "Delegate IAM Access"
+          - Sid: "1. Delegate IAM Access"
             Action:
               - 's3:*'
             Effect: Allow
@@ -186,7 +175,7 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:root"
-          - Sid: "Bucket permissions"
+          - Sid: "2. Read bucket permissions"
             Effect: Allow
             Principal:
               Service:
@@ -197,12 +186,7 @@ Resources:
               - s3:GetBucketLocation
             Resource:
               - !GetAtt PublishedKeysS3Bucket.Arn
-            Condition:
-              StringEquals:
-                  "aws:ResourceTag/key_consumer_type":
-                    - "manage"
-                    - "use"
-          - Sid: "Object permissions"
+          - Sid: "3. Read object permissions"
             Effect: Allow
             Principal:
               Service:
@@ -214,10 +198,43 @@ Resources:
               - !Sub ${PublishedKeysS3Bucket.Arn}/*
             Condition:
               StringEquals:
-                  "aws:ResourceTag/key_consumer_type":
-                    - "manage"
-                    - "use"         
-          - Sid: "Deny all access if not using SecureTransport"
+                  "aws:PrincipalTag/key_consumer_type": "use"
+          - Sid: "4. Deny read object permissions if tag is missing, or not equal to use/manage"
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Action:
+              - "s3:GetObject"
+            Resource:
+              - !Sub ${PublishedKeysS3Bucket.Arn}/*
+            Condition:
+              StringNotEqualsIfExists:
+                "aws:PrincipalTag/key_consumer_type":
+                  - "manage"
+                  - "use"
+          - Sid: "5. Write object permissions for manage tag only"
+            Effect: Allow
+            Principal:
+              AWS: !ImportValue OAuthGenerationFunctionRoleArn
+            Action:
+              - "s3:Put*"
+            Resource:
+              - !Sub ${PublishedKeysS3Bucket.Arn}/*
+            Condition:
+              StringEquals:
+                  "aws:PrincipalTag/key_consumer_type": "manage"
+          - Sid: "6. Deny write object permissions if tag is missing, or not equal to manage"
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Action:
+              - "s3:Put*"
+            Resource:
+              - !Sub ${PublishedKeysS3Bucket.Arn}/*
+            Condition:
+              StringNotEqualsIfExists:
+                "aws:PrincipalTag/key_consumer_type": "manage"
+          - Sid: "7. Deny all access if not using SecureTransport"
             Effect: Deny
             Principal:
               AWS: '*'
@@ -227,37 +244,6 @@ Resources:
             Condition:
               Bool:
                 aws:SecureTransport: false
-
-  PublishedKeysS3BucketLambdaRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: sts:AssumeRole
-            Effect: Allow
-            Principal:
-              Service:
-                - lambda.amazonaws.com
-            Condition:
-              StringEquals:
-                  "aws:ResourceTag/key_consumer_type": "manage"
-                  "aws:ResourceAccount": !Sub ${AWS::AccountId}
-        Version: "2012-10-17"
-      Policies:
-        - PolicyName: PublishedKeysS3BucketPolicy
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:Get*
-                  - s3:Put*
-                Resource:
-                  - !Sub ${PublishedKeysS3Bucket.Arn}/*
-      PermissionsBoundary: !If
-        - UsePermissionsBoundary
-        - !Ref PermissionsBoundary
-        - !Ref AWS::NoValue
 
 Outputs:
 

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -167,7 +167,7 @@ Resources:
         Statement:
           - Sid: "1. Delegate IAM Access"
             Action:
-              - 's3:*'
+              - "s3:*"
             Effect: Allow
             Resource:
               - !GetAtt PublishedKeysS3Bucket.Arn
@@ -175,7 +175,7 @@ Resources:
             Principal:
               AWS:
                 - !Sub "arn:aws:iam::${AWS::AccountId}:root"
-          - Sid: "2. Read bucket permissions"
+          - Sid: "2. Allow Read permissions"
             Effect: Allow
             Principal:
               Service:
@@ -184,38 +184,37 @@ Resources:
             Action:
               - s3:ListBucket
               - s3:GetBucketLocation
+              - s3:GetObject
             Resource:
               - !GetAtt PublishedKeysS3Bucket.Arn
-          - Sid: "3. Read object permissions"
-            Effect: Allow
-            Principal:
-              Service:
-                - apigateway.amazonaws.com
-                - lambda.amazonaws.com
-            Action:
-              - "s3:GetObject"
-            Resource:
               - !Sub ${PublishedKeysS3Bucket.Arn}/*
             Condition:
               StringEquals:
-                  "aws:PrincipalTag/key_consumer_type": "use"
-          - Sid: "4. Deny read object permissions if tag is missing, or not equal to use/manage"
+                  "aws:PrincipalTag/key_consumer_type":
+                    - "use"
+                    - "manage"
+          - Sid: "3. Deny Read permissions if tag is missing, or not equal to use/manage"
             Effect: Deny
             Principal:
               AWS: "*"
             Action:
-              - "s3:GetObject"
+              - s3:ListBucket
+              - s3:GetBucketLocation
+              - s3:GetObject
             Resource:
+              - !GetAtt PublishedKeysS3Bucket.Arn
               - !Sub ${PublishedKeysS3Bucket.Arn}/*
             Condition:
               StringNotEqualsIfExists:
                 "aws:PrincipalTag/key_consumer_type":
                   - "manage"
                   - "use"
-          - Sid: "5. Write object permissions for manage tag only"
+          - Sid: "4. Allow Write permission for manage tag only"
             Effect: Allow
             Principal:
-              AWS: !ImportValue OAuthGenerationFunctionRoleArn
+              Service:
+                - apigateway.amazonaws.com
+                - lambda.amazonaws.com
             Action:
               - "s3:Put*"
             Resource:
@@ -223,7 +222,7 @@ Resources:
             Condition:
               StringEquals:
                   "aws:PrincipalTag/key_consumer_type": "manage"
-          - Sid: "6. Deny write object permissions if tag is missing, or not equal to manage"
+          - Sid: "5. Deny Write permission if tag is missing, or not equal to manage"
             Effect: Deny
             Principal:
               AWS: "*"
@@ -234,11 +233,11 @@ Resources:
             Condition:
               StringNotEqualsIfExists:
                 "aws:PrincipalTag/key_consumer_type": "manage"
-          - Sid: "7. Deny all access if not using SecureTransport"
+          - Sid: "6. Deny all access if not using SecureTransport"
             Effect: Deny
             Principal:
-              AWS: '*'
-            Action: '*'
+              AWS: "*"
+            Action: "*"
             Resource:
               - !Sub ${PublishedKeysS3Bucket.Arn}/*
             Condition:


### PR DESCRIPTION
### What changed

- Updated bucket policy (covers points 2-4 below) so only tagged resources/roles can access the bucket
- Removed extra role that lambda execution role would've originally assumed

### Why did it change

In order for the lambda role to be able to write to the bucket, we need:
1. Explicit allow on identity policy for lambda role: https://github.com/govuk-one-login/identity-key-rotation/pull/98
2. Explicit allow on bucket policy

To limit access to resources with the tags `manage` or `use` we need:
3. Point number 2 above to be conditional on the tags
4. Explicit deny on bucket policy if tags not present or wrong

Policy statements:

1. Delegate IAM access (copied from SPOT)
2. Allow read permissions for the bucket and object, only if:
  Service is APIGW/lambda
  Tag is `use/manage`
3. Deny Read permissions in 2. if tag is missing, or not equal to `use/manage`
4. Allow read permissions for the bucket and object, only if:
  Service is APIGW/lambda
  Tag is `manage`
5. Deny Read permissions in 4. if tag is missing, or not equal to `manage`
6. Deny all access if not using SecureTransport

### Testing

__________________________

- Successful state machine runs with bucket policy attached:

<img width="500" alt="Success" src="https://github.com/user-attachments/assets/2db06935-e023-498c-8b4a-450b674b8d8e" />

__________________________

- Access explicitly denied if `key_consuner_type` is incorrect or missing:

<img width="500" alt="ExplicitDeny" src="https://github.com/user-attachments/assets/cf756922-2bbb-4e53-8fbf-d0f0dad4520b" />


__________________________

- Bucket with bucket policy accessible from lambda and APIGW roles:

<img width="500" alt="ExplicitDeny" src="https://github.com/user-attachments/assets/05284c33-4096-4b90-b439-8cc95e14f3bf" />

__________________________

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1529](https://govukverify.atlassian.net/browse/IPS-1529)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1529]: https://govukverify.atlassian.net/browse/IPS-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ