### PR TITLE
IPS-1529: Allow admin role

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -193,7 +193,7 @@ Resources:
                   "aws:PrincipalTag/key_consumer_type":
                     - "use"
                     - "manage"
-          - Sid: "3. Deny Read permissions if tag is missing, or not equal to use/manage"
+          - Sid: "3. Deny Read permissions if tag is missing, or not equal to use/manage (except for admin role)"
             Effect: Deny
             Principal:
               AWS: "*"
@@ -209,6 +209,8 @@ Resources:
                 "aws:PrincipalTag/key_consumer_type":
                   - "manage"
                   - "use"
+              StringNotLike:
+                 "aws:PrincipalArn": !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_AWSAdministratorAccess*"
           - Sid: "4. Allow Write permission for manage tag only"
             Effect: Allow
             Principal:


### PR DESCRIPTION
### What changed

- Exclude admin role from policy statement that denies read permissions

### Why did it change

- Allow admin role to read from bucket

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1529](https://govukverify.atlassian.net/browse/IPS-1529)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1529]: https://govukverify.atlassian.net/browse/IPS-1529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ