### PR TITLE
IPS-1608: Deploy core infrastructure to cic-dev

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Publish core to ${{ matrix.target }} dev
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, COMMON_DEV, DL_DEV, FRAUD_DEV, HMRC_CHECK_DEV, HMRC_KBV_DEV, KBV_DEV, PASSPORT_DEV, TOY_DEV, IDSRE_DEV ]
+        target: [ ADDRESS_DEV, COMMON_DEV, DL_DEV, FRAUD_DEV, HMRC_CHECK_DEV, HMRC_KBV_DEV, KBV_DEV, PASSPORT_DEV, TOY_DEV, IDSRE_DEV, CIC_DEV ]
         include:
           - target: ADDRESS_DEV
             ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
@@ -54,6 +54,10 @@ jobs:
             ENABLED: "${{ vars.IDSRE_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: IDSRE_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: IDSRE_DEV_CORE_GH_ACTIONS_ROLE_ARN
+          - target: CIC_DEV
+            ENABLED: "${{ vars.CIC_DEV_ENABLED }}"
+            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
+            GH_ACTIONS_ROLE_ARN_SECRET: CIC_DEV_CORE_GH_ACTIONS_ROLE_ARN
 
 
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -271,128 +271,142 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "ac904d389254fffc7cc27a4ec21fca7f71d17f81",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "d01a3f52f7d39e6cac709b097e829721bcef4eea",
+        "is_verified": false,
+        "line_number": 60
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "b1dc1160ee92a55b94f236c75e1aba09b98ad709",
-        "is_verified": false,
-        "line_number": 116
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
-        "is_verified": false,
-        "line_number": 117
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "cf83cfda95b1537fd99d99384b23e889027f4895",
         "is_verified": false,
         "line_number": 120
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "4ce475309b36e6c913feb1893bc52003dac5f2b6",
+        "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
         "is_verified": false,
         "line_number": 121
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
+        "hashed_secret": "cf83cfda95b1537fd99d99384b23e889027f4895",
         "is_verified": false,
         "line_number": 124
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
+        "hashed_secret": "4ce475309b36e6c913feb1893bc52003dac5f2b6",
         "is_verified": false,
         "line_number": 125
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
+        "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
         "is_verified": false,
         "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
+        "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
         "is_verified": false,
         "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "9a166e92ce6c68701ca855ecfd9cb3fef530cb1e",
+        "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
         "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "f69a767cf13cc0bb7f0d2566554e012d7e1cf34c",
+        "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
         "is_verified": false,
         "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "89a689584f85457237ebfeb696363a9b05c92827",
+        "hashed_secret": "9a166e92ce6c68701ca855ecfd9cb3fef530cb1e",
         "is_verified": false,
         "line_number": 136
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "61171cc7b9450583b468f5af5e1cf79328bc737d",
+        "hashed_secret": "f69a767cf13cc0bb7f0d2566554e012d7e1cf34c",
         "is_verified": false,
         "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
+        "hashed_secret": "89a689584f85457237ebfeb696363a9b05c92827",
         "is_verified": false,
         "line_number": 140
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
+        "hashed_secret": "61171cc7b9450583b468f5af5e1cf79328bc737d",
         "is_verified": false,
         "line_number": 141
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "21a7a55c43bda23a529790c4d97ff7131ff4a0d8",
+        "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
         "is_verified": false,
         "line_number": 144
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "7f7d03300aacdacce26ca5edb4ee27cdbc232eb2",
+        "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
         "is_verified": false,
         "line_number": 145
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "a44d5f4bc98a021a65426af87c031e48f39a6cf1",
+        "hashed_secret": "21a7a55c43bda23a529790c4d97ff7131ff4a0d8",
         "is_verified": false,
         "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
-        "hashed_secret": "a22d3f61c7271cbc04c0f2cf5cf6838348ce64ff",
+        "hashed_secret": "7f7d03300aacdacce26ca5edb4ee27cdbc232eb2",
         "is_verified": false,
         "line_number": 149
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "a44d5f4bc98a021a65426af87c031e48f39a6cf1",
+        "is_verified": false,
+        "line_number": 152
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
+        "hashed_secret": "a22d3f61c7271cbc04c0f2cf5cf6838348ce64ff",
+        "is_verified": false,
+        "line_number": 153
       }
     ],
     ".github/workflows/post-merge-publish-txma-infrastructure.yaml": [


### PR DESCRIPTION
### What changed

- Add `cic-dev` to deploy core-infra workflow

### Why did it change

- Kiwi are migrating over from their L2 stacks to common-infrastructure

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1608](https://govukverify.atlassian.net/browse/IPS-1608)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1608]: https://govukverify.atlassian.net/browse/IPS-1608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ