### PR TITLE
IPS-1365: Remove toy

### DIFF
--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Publish txma to ${{ matrix.target }} dev
     strategy:
       matrix:
-        target: [ ADDRESS_DEV, COMMON_DEV, DL_DEV, FRAUD_DEV, HMRC_CHECK_DEV, HMRC_KBV_DEV, KBV_DEV, PASSPORT_DEV, TOY_DEV ]
+        target: [ ADDRESS_DEV, COMMON_DEV, DL_DEV, FRAUD_DEV, HMRC_CHECK_DEV, HMRC_KBV_DEV, KBV_DEV, PASSPORT_DEV ]
         include:
           - target: ADDRESS_DEV
             ENABLED: "${{ vars.ADDRESS_DEV_ENABLED }}"
@@ -47,10 +47,6 @@ jobs:
             ENABLED: "${{ vars.PASSPORT_DEV_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_DEV_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: TOY_DEV
-            ENABLED: "${{ vars.TOY_DEV_ENABLED }}"
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_DEV_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: TOY_DEV_TXMA_GH_ACTIONS_ROLE_ARN
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -105,7 +101,7 @@ jobs:
     needs: publish_txma_to_matrix_dev
     strategy:
       matrix:
-        target: [ ADDRESS_BUILD, COMMON_BUILD, DL_BUILD, FRAUD_BUILD, HMRC_CHECK_BUILD, HMRC_KBV_BUILD, KBV_BUILD, PASSPORT_BUILD, TOY_BUILD ]
+        target: [ ADDRESS_BUILD, COMMON_BUILD, DL_BUILD, FRAUD_BUILD, HMRC_CHECK_BUILD, HMRC_KBV_BUILD, KBV_BUILD, PASSPORT_BUILD ]
         include:
           - target: ADDRESS_BUILD
             ENABLED: "${{ vars.ADDRESS_BUILD_ENABLED }}"
@@ -139,10 +135,6 @@ jobs:
             ENABLED: "${{ vars.PASSPORT_BUILD_ENABLED }}"
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: PASSPORTA_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: PASSPORTA_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
-          - target: TOY_BUILD
-            ENABLED: "${{ vars.TOY_BUILD_ENABLED }}"
-            ARTIFACT_SOURCE_BUCKET_NAME_SECRET: TOY_BUILD_TXMA_ARTIFACT_SOURCE_BUCKET_NAME
-            GH_ACTIONS_ROLE_ARN_SECRET: TOY_BUILD_TXMA_GH_ACTIONS_ROLE_ARN
 
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -511,144 +511,116 @@
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "b089b063c6d9c53c5aae02638908c0c2fc722119",
-        "is_verified": false,
-        "line_number": 52
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "1b81bb8d0323538a63dffdead9bf30c350195c95",
-        "is_verified": false,
-        "line_number": 53
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "405d86708bf3eaf6622c8954dfd23f4496f9224c",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 108
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 109
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "8b40ad9a75978ecf5885ecba18aa91bebded4413",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 112
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "0fb06593bff5fd090b8356aaa07637e41855e4ad",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 113
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 116
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 120
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 121
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "644ed701db5143c463f179028dbc758861de6cf6",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 124
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "c5f66aeadfc064ab45381c470ec70d019aac7ead",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 125
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "a4f084569a90bdd02134f5367ee35f4d20a47cd1",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "3f632b9676f0c73235da0dfeae282d4b2160b471",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "c3be4979751d010cef3d537985818689baacda0d",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 136
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "93d1955ee3c9a219ab0a4225cee8ad283486b896",
         "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "7979a6fea9efaa3e78be5d23c5eb82cd64e48921",
-        "is_verified": false,
-        "line_number": 144
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
-        "hashed_secret": "9b997018ecbc31bd3133c9d26621ef27dc0a02ca",
-        "is_verified": false,
-        "line_number": 145
+        "line_number": 137
       }
     ]
   },
-  "generated_at": "2025-03-24T11:58:27Z"
+  "generated_at": "2025-04-29T09:01:06Z"
 }


### PR DESCRIPTION
### What changed

- Remove TOY accounts from deployment workflow

### Why did it change

- TOY has been decommissioned

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1365](https://govukverify.atlassian.net/browse/IPS-1365)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
