### PR TITLE
IPS-1634: Add environment to jobs

### DIFF
--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -58,6 +58,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: development
     env:
       AWS_REGION: eu-west-2
     permissions:
@@ -150,6 +151,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: build
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/post-merge-publish-txma-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-txma-infrastructure.yaml
@@ -50,6 +50,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: development
     env:
       AWS_REGION: eu-west-2
     permissions:
@@ -138,6 +139,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: build
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -273,126 +273,126 @@
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "b1dc1160ee92a55b94f236c75e1aba09b98ad709",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 118
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "cf83cfda95b1537fd99d99384b23e889027f4895",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 121
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "4ce475309b36e6c913feb1893bc52003dac5f2b6",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 122
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 125
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 126
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "9a166e92ce6c68701ca855ecfd9cb3fef530cb1e",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "f69a767cf13cc0bb7f0d2566554e012d7e1cf34c",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "89a689584f85457237ebfeb696363a9b05c92827",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "61171cc7b9450583b468f5af5e1cf79328bc737d",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 141
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 142
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "21a7a55c43bda23a529790c4d97ff7131ff4a0d8",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 145
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "7f7d03300aacdacce26ca5edb4ee27cdbc232eb2",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 146
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "998f949c48369fecb8e0dd716c9ea33b4592fb4e",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 149
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "09a43bc6cec279eb0fee54a9cd8ffd53dd82de8b",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 150
       }
     ],
     ".github/workflows/post-merge-publish-txma-infrastructure.yaml": [
@@ -513,114 +513,114 @@
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "405d86708bf3eaf6622c8954dfd23f4496f9224c",
         "is_verified": false,
-        "line_number": 108
+        "line_number": 109
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "140170368f49740dc933f3100ac0011fe03bbe6c",
         "is_verified": false,
-        "line_number": 109
+        "line_number": 110
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "8b40ad9a75978ecf5885ecba18aa91bebded4413",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 113
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "0fb06593bff5fd090b8356aaa07637e41855e4ad",
         "is_verified": false,
-        "line_number": 113
+        "line_number": 114
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "b05527397dc2284a871bcf9196ac2ca53aaaf046",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 117
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "caccbcbf236f85b63122f30dcf37bec0944da648",
         "is_verified": false,
-        "line_number": 117
+        "line_number": 118
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "180387550d2222d31ce6b7fcfa237a567f996388",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 121
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "7bb105fb3c4eeedcdd1ad53dc3b2b0f2cb138f37",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 122
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "644ed701db5143c463f179028dbc758861de6cf6",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 125
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "c5f66aeadfc064ab45381c470ec70d019aac7ead",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 126
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "a4f084569a90bdd02134f5367ee35f4d20a47cd1",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 129
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "3f632b9676f0c73235da0dfeae282d4b2160b471",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "2badcdea1850fbb346f8fd580d31ad2a7a432412",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 133
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "3d654850292dcead3723f3dc413dcf60a6980ff7",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 134
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "c3be4979751d010cef3d537985818689baacda0d",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 137
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-txma-infrastructure.yaml",
         "hashed_secret": "93d1955ee3c9a219ab0a4225cee8ad283486b896",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 138
       }
     ]
   },
-  "generated_at": "2025-05-01T11:17:56Z"
+  "generated_at": "2025-05-09T14:54:21Z"
 }


### PR DESCRIPTION
### What changed

- Add `environment` to jobs
- See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-environments-for-deployment#using-an-environment-in-a-workflow

### Why did it change

- To limit the scope of dev/build variables

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1634](https://govukverify.atlassian.net/browse/IPS-1634)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1634]: https://govukverify.atlassian.net/browse/IPS-1634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ