### PR TITLE
OJ-2969: Delete the publish Key bucket in Address-cri DEV

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -2,13 +2,6 @@ AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"
 Description: "Digital Identity IPV CRI Core Infrastructure"
 
-Parameters:
-  Environment:
-    Type: String
-    Default: "none"
-  ServiceName:
-    Type: String
-    Default: "none"
 
 Resources:
   CriVcSigningKey1:
@@ -135,115 +128,6 @@ Resources:
               ArnLike:
                 AWS:SourceArn: !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:*
 
-  PublishedKeysS3Bucket:
-    Type: AWS::S3::Bucket
-    # checkov:skip=CKV_AWS_18: "Ensure the S3 bucket has access logging enabled"
-    Properties:
-      BucketName: !Sub "govuk-one-login-${ServiceName}-published-keys-${Environment}"
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
-      VersioningConfiguration:
-        Status: Enabled
-      NotificationConfiguration:
-        EventBridgeConfiguration:
-          EventBridgeEnabled: true
-      Tags:
-        - Key: "Description"
-          Value: "Published OAuth or DID keys bucket for key rotation state machine"
-
-  PublishedKeysS3BucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref PublishedKeysS3Bucket
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: "1. Delegate IAM Access"
-            Action:
-              - "s3:*"
-            Effect: Allow
-            Resource:
-              - !GetAtt PublishedKeysS3Bucket.Arn
-              - !Sub ${PublishedKeysS3Bucket.Arn}/*
-            Principal:
-              AWS:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:root"
-          - Sid: "2. Allow Read permissions"
-            Effect: Allow
-            Principal:
-              Service:
-                - apigateway.amazonaws.com
-                - lambda.amazonaws.com
-            Action:
-              - s3:ListBucket
-              - s3:GetBucketLocation
-              - s3:GetObject
-            Resource:
-              - !GetAtt PublishedKeysS3Bucket.Arn
-              - !Sub ${PublishedKeysS3Bucket.Arn}/*
-            Condition:
-              StringEquals:
-                  "aws:PrincipalTag/key_consumer_type":
-                    - "use"
-                    - "manage"
-          - Sid: "3. Deny Read permissions if tag is missing, or not equal to use/manage"
-            Effect: Deny
-            Principal:
-              AWS: "*"
-            Action:
-              - s3:ListBucket
-              - s3:GetBucketLocation
-              - s3:GetObject
-            Resource:
-              - !GetAtt PublishedKeysS3Bucket.Arn
-              - !Sub ${PublishedKeysS3Bucket.Arn}/*
-            Condition:
-              StringNotEqualsIfExists:
-                "aws:PrincipalTag/key_consumer_type":
-                  - "manage"
-                  - "use"
-          - Sid: "4. Allow Write permission for manage tag only"
-            Effect: Allow
-            Principal:
-              Service:
-                - apigateway.amazonaws.com
-                - lambda.amazonaws.com
-            Action:
-              - "s3:Put*"
-            Resource:
-              - !Sub ${PublishedKeysS3Bucket.Arn}/*
-            Condition:
-              StringEquals:
-                  "aws:PrincipalTag/key_consumer_type": "manage"
-          - Sid: "5. Deny Write permission if tag is missing, or not equal to manage"
-            Effect: Deny
-            Principal:
-              AWS: "*"
-            Action:
-              - "s3:Put*"
-            Resource:
-              - !Sub ${PublishedKeysS3Bucket.Arn}/*
-            Condition:
-              StringNotEqualsIfExists:
-                "aws:PrincipalTag/key_consumer_type": "manage"
-          - Sid: "6. Deny all access if not using SecureTransport"
-            Effect: Deny
-            Principal:
-              AWS: "*"
-            Action: "*"
-            Resource:
-              - !Sub ${PublishedKeysS3Bucket.Arn}/*
-            Condition:
-              Bool:
-                aws:SecureTransport: false
-
 Outputs:
 
   TableNameSession1:
@@ -293,13 +177,3 @@ Outputs:
     Value: !Ref AlarmTopic
     Export:
       Name: !Sub ${AWS::StackName}-AlarmTopic
-
-  PublishedKeysS3BucketName:
-    Value: !Ref PublishedKeysS3Bucket
-    Export:
-      Name: !Sub ${AWS::StackName}-PublishedKeysS3BucketName
-
-  PublishedKeysS3BucketArn:
-    Value: !GetAtt PublishedKeysS3Bucket.Arn
-    Export:
-      Name: !Sub ${AWS::StackName}-PublishedKeysS3BucketArn


### PR DESCRIPTION
## Proposed changes

**NO LONGER INTEND TO MERGE THIS** will the trigger the workflow manually

The address-cri bucket for  `.well-known/jwks.json` endpoint is only expected to have one item at the end of rotation. The `dev` now has 3 items. The only to remove them is to delete the bucket.

**Once this is done the PR would be reverted**

### What changed

While looking into the possibility of addressing AC2 and AC3 as part of [OJ-2969](https://govukverify.atlassian.net/browse/OJ-2969), the acceptance-test was run. In any case running test in it's current form and not on `di-idsre-dev` can lead to this issue

### Why did it change

This PR is to remove the content of the dev bucket in the address-cri, by deleting the bucket, all the other DEV environment has been set to false except for `ADDRESS_DEV_ENABLED=true`

![image](https://github.com/user-attachments/assets/9a31f149-d89c-410d-aa82-d97f8087cf17)

### Issue tracking

- [OJ-2969](https://govukverify.atlassian.net/browse/OJ-2969)



[OJ-2969]: https://govukverify.atlassian.net/browse/OJ-2969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OJ-2969]: https://govukverify.atlassian.net/browse/OJ-2969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ