### PR TITLE
IPS-1598: Add Object Lock to keys bucket

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,4 +1,4 @@
-# Address CRI Core Resources
+# CRI Core Resources
 
 Deploy core resources that should not change often into their own stack with a separate deploy lifecycle.
 
@@ -7,12 +7,18 @@ These resources are:
 * KMS keys
 * DynamoDB tables
 * API keys
+* S3 bucket with `jwks.json` to store public keys
 
 The names and exported names of these resources will be prefixed with the API stack name `di-ipv-cri-address-core-infra`.
 
 As a developer, you will be use these shared core stack resources by default, or you can choose to deploy your own core stack.
 
 Note that SSM params are not yet part of this stack.
+
+> [!IMPORTANT]
+> The published keys bucket has `ObjectLock` enabled as per the RFC for key-rotation. This is enabled in `COMPLIANCE` mode in production, and `GOVERNANCE` mode in lower environments. This protects the `jwks.json` file and means it cannot be overwritten or deleted by any user. See AWS docs [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html).
+>
+> For development work, it is advised to disable `ObjectLock` and remove `ObjectLockConfiguration` so the dev file can be deleted once the ticket is complete.
 
 ## Deployment
 

--- a/core/README.md
+++ b/core/README.md
@@ -18,7 +18,7 @@ Note that SSM params are not yet part of this stack.
 > [!IMPORTANT]
 > The published keys bucket has `ObjectLock` enabled as per the RFC for key-rotation. This is enabled in `COMPLIANCE` mode in production, and `GOVERNANCE` mode in lower environments. This protects the `jwks.json` file and means it cannot be overwritten or deleted by any user. See AWS docs [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html).
 >
-> For development work, it is advised to disable `ObjectLock` and remove `ObjectLockConfiguration` so the dev file can be deleted once the ticket is complete.
+> For development work, i.e if the core stack is deployed via sam deploy, `ObjectLock` and `ObjectLockConfiguration` is switched off so the dev file can be deleted once the ticket is complete.
 
 ## Deployment
 

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -158,7 +158,7 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      ObjectLockEnabled: true
+      ObjectLockEnabled: true # If testing in dev with a local stack, remove `ObjectLockEnabled` and the `ObjectLockConfiguration` section below. See README.md for further details.
       ObjectLockConfiguration:
         ObjectLockEnabled: Enabled
         Rule:

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -5,8 +5,9 @@ Description: "Digital Identity IPV CRI Core Infrastructure"
 Parameters:
   Environment:
     Type: String
-    Default: "dev"
+    Default: "local"
     AllowedValues:
+      - "local"
       - "dev"
       - "build"
       - "staging"
@@ -17,6 +18,11 @@ Parameters:
     Default: "none"
 
 Conditions:
+  IsDev: !Equals [!Ref Environment, dev]
+  IsLocal: !Equals [!Ref Environment, local]
+  IsNotLocal: !Not [!Condition IsLocal]
+  IsDevOrLocal: !Or [!Condition IsDev, !Condition IsLocal]
+  IsNotDevOrLocal: !Not [!Condition IsDevOrLocal]
   IsProd: !Equals [!Ref Environment, production]
 
 Resources:
@@ -158,13 +164,15 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
-      ObjectLockEnabled: true # If testing in dev with a local stack, remove `ObjectLockEnabled` and the `ObjectLockConfiguration` section below. See README.md for further details.
-      ObjectLockConfiguration:
-        ObjectLockEnabled: Enabled
-        Rule:
-          DefaultRetention:
-            Mode: !If [ IsProd, "COMPLIANCE", "GOVERNANCE" ]
-            Days: 1
+      ObjectLockEnabled: !If [ IsNotDevOrLocal, true, !Ref "AWS::NoValue" ]
+      ObjectLockConfiguration: !If
+        - IsNotDevOrLocal
+        - ObjectLockEnabled: Enabled
+          Rule:
+            DefaultRetention:
+              Mode: !If [ IsProd, "COMPLIANCE", "GOVERNANCE" ]
+              Days: 1
+        - !Ref "AWS::NoValue"
       VersioningConfiguration:
         Status: Enabled
       NotificationConfiguration:
@@ -176,6 +184,7 @@ Resources:
 
   PublishedKeysS3BucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Condition: IsNotLocal
     Properties:
       Bucket: !Ref PublishedKeysS3Bucket
       PolicyDocument:

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -1,14 +1,23 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: "AWS::Serverless-2016-10-31"
+Transform: [ AWS::LanguageExtensions, AWS::Serverless-2016-10-31 ]
 Description: "Digital Identity IPV CRI Core Infrastructure"
 
 Parameters:
   Environment:
     Type: String
-    Default: "none"
+    Default: "dev"
+    AllowedValues:
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
   ServiceName:
     Type: String
     Default: "none"
+
+Conditions:
+  IsProd: !Equals [!Ref Environment, production]
 
 Resources:
   CriVcSigningKey1:
@@ -149,6 +158,13 @@ Resources:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
+      ObjectLockEnabled: true
+      ObjectLockConfiguration:
+        ObjectLockEnabled: Enabled
+        Rule:
+          DefaultRetention:
+            Mode: !If [ IsProd, "COMPLIANCE", "GOVERNANCE" ]
+            Days: 1
       VersioningConfiguration:
         Status: Enabled
       NotificationConfiguration:


### PR DESCRIPTION
### What changed

- Add `ObjectLock` to keys bucket
- Set to`COMPLIANCE` mode in prod and `GOVERNANCE` in lower envs (for feature parity in development, as advised the RFC)

<kbd>
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/acc9c18c-6cf7-44e8-9632-23d454c865a1" />
</kbd>


### Why did it change

- As outlined in the RFC: https://govukverify.atlassian.net/wiki/spaces/DID/pages/5014224958/OAuth+Encryption+Signing+Keys+-+Scope
> The RFC describes the use of ObjectLock in compliance mode on s3 objects for production level resiliency. This allows for a fix forward approach only, with each new revision being immutable and fully auditable. This is a security requirement for production level environments. Non-production environments may use Governance mode. Development environments may choose whether to enable Object Lock at all. 
> Aiming for feature parity in development is advised for greater confidence in the developed software and processes for operating it.

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1598](https://govukverify.atlassian.net/browse/IPS-1598)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1598]: https://govukverify.atlassian.net/browse/IPS-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ