### PR TITLE
LIME-1664 Add secure pipeline, codesigning and use separate output directory for code building

### DIFF
--- a/.github/workflows/kiwi-post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/kiwi-post-merge-publish-core-infrastructure.yaml
@@ -60,15 +60,22 @@ jobs:
       - name: SAM Validate
         id: sam-validate
         if: ${{ steps.setup-aws-role.conclusion == 'success' }}
-        run: sam validate --region ${{ env.AWS_REGION }} -t core/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t core/template.yaml --lint
+
+      - name: SAM build
+        id: sam-build
+        if: ${{ steps.sam-validate.conclusion == 'success' }}
+        run: |
+          mkdir out
+          sam build -t core/template.yaml -b out/
 
       - name: Deploy SAM template
-        if: ${{ steps.sam-validate.conclusion == 'success' }}
+        if: ${{ steps.sam-build.conclusion == 'success' }}
         uses: govuk-one-login/devplatform-upload-action@v3.9.2
         with:
             artifact-bucket-name: ${{ vars[format('{0}_CORE_ARTIFACT_SOURCE_BUCKET_NAME', matrix.target)] }}
-            signing-profile-name: ""
-            working-directory: ./core
+            signing-profile-name: ${{ vars[format('{0}_CORE_SIGNING_PROFILE_NAME', matrix.target)] }}
+            working-directory: ./out
 
       - name: Inform of disabled status
         if: matrix.ENABLED != 'true'
@@ -124,15 +131,22 @@ jobs:
       - name: SAM Validate
         id: sam-validate
         if: ${{ steps.setup-aws-role.conclusion == 'success' }}
-        run: sam validate --region ${{ env.AWS_REGION }} -t core/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t core/template.yaml --lint
+
+      - name: SAM build
+        id: sam-build
+        if: ${{ steps.sam-validate.conclusion == 'success' }}
+        run: |
+          mkdir out
+          sam build -t core/template.yaml -b out/
 
       - name: Deploy SAM template
-        if: ${{ steps.sam-validate.conclusion == 'success' }}
+        if: ${{ steps.sam-build.conclusion == 'success' }}
         uses: govuk-one-login/devplatform-upload-action@v3.9.2
         with:
-            artifact-bucket-name: ${{ vars[format('{0}_CORE_ARTIFACT_SOURCE_BUCKET_NAME', matrix.target)] }}
-            signing-profile-name: ""
-            working-directory: ./core
+          artifact-bucket-name: ${{ vars[format('{0}_CORE_ARTIFACT_SOURCE_BUCKET_NAME', matrix.target)] }}
+          signing-profile-name: ${{ vars[format('{0}_CORE_SIGNING_PROFILE_NAME', matrix.target)] }}
+          working-directory: ./out
 
       - name: Inform of disabled status
         if: matrix.ENABLED != 'true'

--- a/.github/workflows/post-merge-publish-core-infrastructure.yaml
+++ b/.github/workflows/post-merge-publish-core-infrastructure.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   publish_core_to_matrix_dev:
     name: Publish core to ${{ matrix.target }} dev
+    environment: ${{ matrix.target }}
     strategy:
       matrix:
         target: [ ADDRESS_DEV, COMMON_DEV, DL_DEV, FRAUD_DEV, HMRC_CHECK_DEV, HMRC_KBV_DEV, KBV_DEV, PASSPORT_DEV, IDSRE_DEV, CIC_DEV ]
@@ -55,7 +56,6 @@ jobs:
             ARTIFACT_SOURCE_BUCKET_NAME_SECRET: CIC_DEV_CORE_ARTIFACT_SOURCE_BUCKET_NAME
             GH_ACTIONS_ROLE_ARN_SECRET: CIC_DEV_CORE_GH_ACTIONS_ROLE_ARN
 
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -90,18 +90,20 @@ jobs:
       - name: SAM Validate
         if: matrix.ENABLED == 'true'
         run: sam validate --region ${{ env.AWS_REGION }} -t core/template.yaml --lint
-      
+
       - name: SAM build
         if: matrix.ENABLED == 'true'
-        run: sam build -t core/template.yaml
+        run: |
+          mkdir out
+          sam build -t core/template.yaml -b out/
 
       - name: Deploy SAM template
         if: matrix.ENABLED == 'true'
         uses: govuk-one-login/devplatform-upload-action@v3.9.2
         with:
             artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-            signing-profile-name: ""
-            working-directory: ./core
+            signing-profile-name: ${{ vars[format('{0}_CORE_SIGNING_PROFILE_NAME', matrix.target)] }}
+            working-directory: ./out
 
       - name: Inform of disabled status
         if: matrix.ENABLED != 'true'
@@ -111,6 +113,7 @@ jobs:
   publish_core_to_matrix_build:
     name: Publish core to ${{ matrix.target }} build
     needs: publish_core_to_matrix_dev
+    environment: ${{ matrix.target }}
     strategy:
       matrix:
         target: [ ADDRESS_BUILD, COMMON_BUILD, DL_BUILD, FRAUD_BUILD, HMRC_CHECK_BUILD, HMRC_KBV_BUILD, KBV_BUILD, PASSPORT_BUILD, CIC_BUILD ]
@@ -189,15 +192,17 @@ jobs:
 
       - name: SAM build
         if: matrix.ENABLED == 'true'
-        run: sam build -t core/template.yaml
+        run: |
+          mkdir out
+          sam build -t core/template.yaml -b out/
 
       - name: Deploy SAM template
         if: matrix.ENABLED == 'true'
         uses: govuk-one-login/devplatform-upload-action@v3.9.2
         with:
             artifact-bucket-name: ${{ secrets[matrix.ARTIFACT_SOURCE_BUCKET_NAME_SECRET] }}
-            signing-profile-name: ""
-            working-directory: ./core
+            signing-profile-name: ${{ vars[format('{0}_CORE_SIGNING_PROFILE_NAME', matrix.target)] }}
+            working-directory: ./out
 
       - name: Inform of disabled status
         if: matrix.ENABLED != 'true'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,266 +133,266 @@
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "f555b8b7a93dd8bb8d31a74f62be538851b0f9f1",
         "is_verified": false,
-        "line_number": 19
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "006202d6e6394bb7151c39053189ce028172b28d",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 21
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "7ae2b0511da65aba76a7e28c3e93971876d4ea51",
         "is_verified": false,
-        "line_number": 23
+        "line_number": 24
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "2d09e8cbade61c6a810f2ae56b108575d69993ce",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 25
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "15c1a36e0b8d2856f84b28198d9c271e259018da",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 28
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "3b447b2b970b3fa8b194970d95de8322a8f92d3b",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 29
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "3c9195fc6a5ee030d6483eab463f8319d49c0811",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 32
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "4b5396320488f7f35b90e23dfc4b55aef695b07d",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 33
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "53b66139c757af44e876b73144462770ac1a89d4",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 36
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "8586ef52076dab450b948e85f7d054f3ba3ee696",
         "is_verified": false,
-        "line_number": 36
+        "line_number": 37
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "98cb0b22bae9a1e9e8f965b7221f0cad92ccc713",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 40
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "46faa494579d521cb49c043d38a8bbb3617d55e6",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 41
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "48554134b06ac14ccfabce8e48461579af547db0",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 44
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "ad5f0a29d30d5ee60c2e291b4bd1f9ffa22c5bea",
         "is_verified": false,
-        "line_number": 44
+        "line_number": 45
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "e959bfefa7dc9de9d4a01b35b2fe4f0c8ea48414",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 48
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "9deae82cb991c2f4529712299a87e485ee62fe8b",
         "is_verified": false,
-        "line_number": 48
+        "line_number": 49
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "19dce172b5727991b4765bc3d2cdf80acf0f2254",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 52
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "4be3dedebf97465e0011135747c03143ee8e8132",
         "is_verified": false,
-        "line_number": 52
+        "line_number": 53
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "ac904d389254fffc7cc27a4ec21fca7f71d17f81",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 56
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "d01a3f52f7d39e6cac709b097e829721bcef4eea",
         "is_verified": false,
-        "line_number": 56
+        "line_number": 57
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "b1dc1160ee92a55b94f236c75e1aba09b98ad709",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 123
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "57bc192a9a0d13830bcb6be1a7a3d888fee16cbb",
         "is_verified": false,
-        "line_number": 121
+        "line_number": 124
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "cf83cfda95b1537fd99d99384b23e889027f4895",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 127
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "4ce475309b36e6c913feb1893bc52003dac5f2b6",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 128
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "fe5656a36a48fb32150343b41a685d33c31d6315",
         "is_verified": false,
-        "line_number": 128
+        "line_number": 131
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "d3189078223b790e1119ec0b8b388626e3a16f06",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "ee8e1238c7ce79f52cee95046b879b37048ac7bf",
         "is_verified": false,
-        "line_number": 132
+        "line_number": 135
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "25e415d6b261c36fcb316695f5eca13e6bce1dd1",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 136
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "9a166e92ce6c68701ca855ecfd9cb3fef530cb1e",
         "is_verified": false,
-        "line_number": 136
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "f69a767cf13cc0bb7f0d2566554e012d7e1cf34c",
         "is_verified": false,
-        "line_number": 137
+        "line_number": 140
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "89a689584f85457237ebfeb696363a9b05c92827",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 143
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "61171cc7b9450583b468f5af5e1cf79328bc737d",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 144
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "2e31053dcac98f6ca479075b71c3ec58dcbe98c1",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "7c929a3efa3dc2c638d571e69d8cbc040a5d22a3",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "21a7a55c43bda23a529790c4d97ff7131ff4a0d8",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 151
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "7f7d03300aacdacce26ca5edb4ee27cdbc232eb2",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 152
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "998f949c48369fecb8e0dd716c9ea33b4592fb4e",
         "is_verified": false,
-        "line_number": 152
+        "line_number": 155
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/post-merge-publish-core-infrastructure.yaml",
         "hashed_secret": "09a43bc6cec279eb0fee54a9cd8ffd53dd82de8b",
         "is_verified": false,
-        "line_number": 153
+        "line_number": 156
       }
     ],
     ".github/workflows/post-merge-publish-txma-infrastructure.yaml": [
@@ -622,5 +622,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-02T14:52:13Z"
+  "generated_at": "2025-06-12T08:16:47Z"
 }

--- a/core/template.yaml
+++ b/core/template.yaml
@@ -9,12 +9,29 @@ Parameters:
   ServiceName:
     Type: String
     Default: "none"
+  CodeSigningConfigArn:
+    Type: String
+    Description: >
+      The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Default: "none"
+  PermissionsBoundary:
+    Type: String
+    Description: >
+      The ARN of the permissions boundary to apply to any role created by the template
+    Default: "none"
 #  VpcStackName:
 #    Description: VPC Stack name
 #    Type: String
 #    Default: "none"
   
-#Conditions:
+Conditions:
+  UseCodeSigning: !Not
+    - !Equals [!Ref CodeSigningConfigArn, "none"]
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - "none"
 #  UseVpc:
 #    Fn::Not:
 #      - Fn::Equals:
@@ -275,6 +292,14 @@ Resources:
           POWERTOOLS_LOG_LEVEL: INFO
           POWERTOOLS_METRICS_NAMESPACE: !Sub "${AWS::StackName}"
           POWERTOOLS_SERVICE_NAME: !Sub "${AWS::StackName}-publishKey"
+      CodeSigningConfigArn: !If
+        - UseCodeSigning
+        - !Ref CodeSigningConfigArn
+        - !Ref AWS::NoValue
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
 #      VpcConfig: !If
 #        - UseVpc
 #        - SecurityGroupIds:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Add secure pipeline permission boundary, 
Add codesigning arn
Use separate output directory for code building
Added code signing name variable to git hub, 
- only lime CRI values set due to access limitations

(Updated KIWI action to follow - but untested)

### Why did it change

Permission boundary required for the lambda role creation/
The lambda code is required to be signed.
Due to the addition of a lamdba reusing the project directory results in source code getting uploaded, a separate output directory is needed.
Code signing name variables - needed for the new lambda in the secure pipeline

(KIWI action needs the same changes - but untested)

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1664](https://govukverify.atlassian.net/browse/LIME-1664)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-1664]: https://govukverify.atlassian.net/browse/LIME-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ