### PR TITLE
IPS-1544: Add bucket alarms

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -461,7 +461,7 @@ Resources:
             Condition:
               Bool:
                 "aws:SecureTransport": false
-          
+
   Trail:
     DependsOn:
       - PublishedKeysLogsBucketPolicy
@@ -480,7 +480,7 @@ Resources:
                   - ""
                   - - !GetAtt PublishedKeysS3Bucket.Arn
                     - "/"
-          IncludeManagementEvents: true
+          IncludeManagementEvents: false
           ReadWriteType: All
       S3BucketName: !Ref PublishedKeysLogsBucket
       EnableLogFileValidation: true
@@ -535,7 +535,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotDevOrLocal
     Properties:
-      AlarmName: PublishedKeysS3BucketObjectActionAlarm
+      AlarmName: !Sub ${AWS::StackName}-PublishedKeysS3BucketObjectActionAlarm
       AlarmDescription: !Sub "A role other than the `OAuthGenerationFunctionRole` has attempted to `PutObject` or `DeleteObject` to `${PublishedKeysS3Bucket.Arn}`. Check Cloudwatch for further details."
       MetricName: UnauthorisedS3ObjectAction
       Namespace: PublishedKeysBucket
@@ -563,7 +563,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotDevOrLocal
     Properties:
-      AlarmName: PublishedKeysBucketConfigChangeAlarm
+      AlarmName: !Sub ${AWS::StackName}-PublishedKeysBucketConfigChangeAlarm
       AlarmDescription: !Sub "Changes have been made to `${PublishedKeysS3Bucket.Arn}`, for example, a `DeleteBucketPolicy`, `DeleteBucketLifecycle` or `PutBucketCors` event. Check Cloudwatch for further details."
       MetricName: PublishedKeysBucketConfigChange
       Namespace: PublishedKeysBucket


### PR DESCRIPTION
### What changed

- Sorted parameters alphabetically
- Added resources for bucket alarms (only in Build and higher):
  - PublishedKeysS3BucketLogGroup
  - PublishedKeysLogsBucket
  - PublishedKeysLogsBucketPolicy
  - CloudTrail (writes to `PublishedKeysLogsBucket` above)
  - TrailLogGroupRole
  - PublishedKeysS3BucketObjectActionsMetricFilter (covers unauthorised `PutObject` or `DeleteObject` events)
  - PublishedKeysS3BucketObjectActionAlarm
  - PublishedKeysBucketConfigChangeMetricFilter (covers events such as `DeleteBucketPolicy`, `DeleteBucketLifecycle` or `PutBucketCors`)
  - PublishedKeysBucketConfigChangeAlarm

- Used Cloudtrail logs, see:
  - https://aws.amazon.com/blogs/mt/how-to-detect-and-monitor-amazon-simple-storage-service-s3-access-with-aws-cloudtrail-and-amazon-cloudwatch/
  - https://repost.aws/questions/QUktXj6H2NT1mPM3ZTulhTOA/s3-server-access-logs-to-cloudwatch
  - https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudtrail-trail-dataresource.html

### Why did it change

- To send an alert if:
- A role other than the `OAuthGenerationFunctionRole` has attempted to `PutObject` or `DeleteObject`
- Other config changes occur

### Testing

- Manually triggering alarm:

<kbd>
<img width="548" alt="image" src="https://github.com/user-attachments/assets/cebe9af0-fe3f-4f8f-b120-1ac15fb1e2bf" />
</kbd>

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1544](https://govukverify.atlassian.net/browse/IPS-1544)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1544]: https://govukverify.atlassian.net/browse/IPS-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ