### PR TITLE
IPS-1956 removed import value and defined it with a wildcard at the end

### DIFF
--- a/core/template.yaml
+++ b/core/template.yaml
@@ -522,9 +522,7 @@ Resources:
             - - '{'
               - '($.eventSource = s3.amazonaws.com) &&'
               - '($.eventName = DeleteObject || $.eventName = PutObject) &&'
-              - '($.userIdentity.arn != "'
-              - !ImportValue OAuthGenerationFunctionRoleArn
-              - '")'
+              - '($.userIdentity.arn != "*OAuthGenerationFunctionRole*")'
               - '}'
         MetricTransformations:
           - MetricName: UnauthorisedS3ObjectAction


### PR DESCRIPTION
## Proposed changes

### What changed

Removed import of OAuthGenerationFunctionRoleArn and instead hard coding the value OAuthGenerationFunctionRole and including a wildcard

### Why did it change

To remove coupling of the stacks
Currently the role can be called something like {StackName}-{LogicalResourceId}-{RandomString}
e.g. 
key-rotation-OAuthGenerationFunctionRole-3gr5gsdg4

Test:

<img width="992" height="614" alt="image" src="https://github.com/user-attachments/assets/9491f3b3-bfb9-4262-9617-e97ebd94959e" />
Alarm notification sent when I updated the bucket with a different role - remove-contents-of-key-bucket-role-XXX but no notifications sent when I updated the bucket with the existing role

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1956](https://govukverify.atlassian.net/browse/IPS-1956)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-1956]: https://govukverify.atlassian.net/browse/IPS-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ